### PR TITLE
Update esri-leaflet dependency to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "leaflet": "^1.0.0",
-    "esri-leaflet": "^2.0.0"
+    "esri-leaflet": "^3.0.0"
   },
   "devDependencies": {
     "chai": "2.3.0",


### PR DESCRIPTION
This PR would update the esri-leaflet dependency to from ^2.0.0 to ^3.0.0.  This should resolve [this issue](https://github.com/jgravois/esri-leaflet-related/issues/21)